### PR TITLE
trim custom options json

### DIFF
--- a/cypress-multi-reporters/lib/MultiReporters.js
+++ b/cypress-multi-reporters/lib/MultiReporters.js
@@ -161,7 +161,7 @@ MultiReporters.prototype.getCustomOptions = function (options) {
                 customOptions = require(customOptionsFile);
             }
             else {
-                customOptions = JSON.parse(fs.readFileSync(customOptionsFile).toString());
+                customOptions = JSON.parse(fs.readFileSync(customOptionsFile).toString().trim());
             }
 
             debug('options (custom)', customOptions);


### PR DESCRIPTION
Wasted a little of time trying to get this to read my reporter config json file, which kept returning unexpected ' '. Found that adding this trim() fixed the issue. I switched to using a .js config file, but this might keep someone else from a moments frustration 😄