### PR TITLE
fix(cypress-multi-reporters): passing `reportOption` as an alias of `reportOptions` to match expectations in mocha

### DIFF
--- a/cypress-multi-reporters/lib/MultiReporters.js
+++ b/cypress-multi-reporters/lib/MultiReporters.js
@@ -93,7 +93,8 @@ function MultiReporters(runner, options) {
                 if (Reporter !== null) {
                     return new Reporter(
                         runner, {
-                            reporterOptions
+                            reporterOptions,
+                            reporterOption: reporterOptions
                         }
                     );
                 }


### PR DESCRIPTION
This resolves issues with being unable to pass options to reporters complying with the newer `reportOption` name, as noted here: https://github.com/mochajs/mocha/issues/4741

This change has been manually verified to work with mocha's built-in `json` reporter.