### PR TITLE
chore: update cypress-multi-reporters repository and homepage URLs

### DIFF
--- a/cypress-multi-reporters/package.json
+++ b/cypress-multi-reporters/package.json
@@ -24,13 +24,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/you54f/cypress-multi-reporters"
+    "url": "https://github.com/YOU54F/cypress-plugins"
   },
   "engines": {
     "node": ">=6.0.0"
   },
-  "bugs": "https://github.com/you54f/cypress-multi-reporters/issues",
-  "homepage": "https://github.com/you54f/cypress-multi-reporters",
+  "bugs": "https://github.com/YOU54F/cypress-plugins/issues",
+  "homepage": "https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters",
   "license": "MIT",
   "dependencies": {
     "debug": "^4.3.7",

--- a/cypress-slack-reporter-old/README.md
+++ b/cypress-slack-reporter-old/README.md
@@ -116,7 +116,7 @@ eg. `export SLACK_WEBHOOK_URL=your1stWebhookUrlHere,your2ndWebhookUrlHere`
 - [mochawesome](https://github.com/adamgruber/mochawesome/) for json test result generation
 - [mochawesome-merge](https://github.com/Antontelesh/mochawesome-merge) to combine multiple mochawesome reports
 - [mochawesome-report-generator](https://github.com/Antonteleshmochawesome-report-generator) to generate a HTML report, from your mochawesome json test results
-- [cypress-multi-reporters](https://github.com/you54f/cypress-multi-reporters) to allow you to use multple reporters, in case you require other outputs (junit/spec etc)
+- [cypress-multi-reporters](https://github.com/YOU54F/cypress-plugins/tree/master/cypress-multi-reporters) to allow you to use multiple reporters, in case you require other outputs (junit/spec etc)
 
 Yarn installation Instructions
 


### PR DESCRIPTION
## Description

Update the repository, bugs, and homepage URLs in `cypress-multi-reporters/package.json` to point to the new location under `cypress-plugins` monorepo. This change ensures consistency with the actual repository location and helps users find the correct source code and issue tracker.

## Changes
- Update repository URL
- Update bugs URL
- Update homepage URL
- Update cypress-slack-reporter-old/README.md